### PR TITLE
Add .htaccess for SPA routing on cPanel/Apache

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,4 @@
+Options -MultiViews
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^ index.html [QSA,L]


### PR DESCRIPTION
Rewrites all non-file requests to index.html so React Router handles client-side routing on Apache. Without this, direct URL access to routes like /projects returns a 404 on cPanel.